### PR TITLE
Maybe specify /bin/bash since you are using pushd/popd?

### DIFF
--- a/modem.sh
+++ b/modem.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 ### constants


### PR DESCRIPTION
I'm not a shell script expert but I ran this on pureos(debian) and it did quite a bit of work before failing on the pushd step due to /bin/sh not being bash but rather dash. I know this is a common problem with debian. An alternative would be to avoid pushd/popd I suppose.