### PR TITLE
MacOS compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,19 @@
 # Makefile by Roberto M.F. (Roboe)
 # https://github.com/WeAreFairphone/flashabe-zip_emojione
 
-SHELL     := /bin/bash
+SHELL       := /bin/bash
+
+# Dependencies
+CURL        := $(shell command -v curl 2>&1)
+ZIP         := $(shell command -v zip 2>&1)
+UNZIP       := $(shell command -v unzip 2>&1)
+ifeq ($(uname -s),"Darwin")
+  SHA256SUM := $(shell command -v gsha256sum 2>&1)
+  MKTEMP    := $(shell command -v gmktemp 2>&1)
+else
+  SHA256SUM := $(shell command -v sha256sum 2>&1)
+  MKTEMP    := $(shell command -v mktemp 2>&1)
+endif
 
 # Version and release
 VERSION      := 18.04.1
@@ -15,19 +27,13 @@ SOURCE       := ./src/
 FIRMWARE_DIR := ./src/firmware-update/
 EDIFY_BINARY := ./src/META-INF/com/google/android/update-binary
 EDIFY_SCRIPT := ./src/META-INF/com/google/android/updater-script
-TEMP_DIR     := $(shell mktemp --dry-run -d /tmp/modem.XXXXXXXX)
+TEMP_DIR     := $(shell $(MKTEMP) --dry-run -d /tmp/modem.XXXXXXXX)
 
 # Update ZIPs
 OTA_FILENAME := fp2-sibon-$(VERSION)-ota-userdebug.zip
 OTA_FILE     := ./updates/$(OTA_FILENAME)
 OTA_URL      := https://storage.googleapis.com/fairphone-updates/6cb84543-9614-425d-9ab4-9e80baca2b8f/$(OTA_FILENAME)
 OTA_CHECKSUM := 97b39681b773804c8e12177293171698395c43ad9458c7ba823c85c503f00500
-
-# Dependencies
-CURL      := $(shell command -v curl 2>&1)
-ZIP       := $(shell command -v zip 2>&1)
-UNZIP     := $(shell command -v unzip 2>&1)
-SHA256SUM := $(shell if [[ "$(uname -s)" == "Darwin" ]]; then command -v gsha256sum; else command -v sha256sum; fi)
 
 
 .PHONY: all build clean release install


### PR DESCRIPTION
**Must fix #4 once before merging.**

This PR specifically replaces `mktemp` with `gmktemp`. `gmktemp` is available in GNU coreutils (`$ brew install coreutils`).
I could have written the command like `mktemp -u` instead of `mktemp --dry-run`, but I decided to keep readability because we already need `coreutils` to provide `gsha256sum`.  

Please, @jfdhuiz, could you test this on your machine?