### PR TITLE
MacOS compatibility (again)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ $(FLASHABLEZIP): $(FIRMWARE_DIR) $(EDIFY_BINARY) $(EDIFY_SCRIPT)
 	@echo "Building flashable ZIP..."
 	@mkdir -pv "$(@D)"
 	@rm -f "$@"
-	@cd "$(TEMP_DIR)" && $(FIND) -type f | $(SORT) | $(ZIP) -X \
+	@cd "$(TEMP_DIR)" && $(FIND) -type f | LC_ALL=C $(SORT) | $(ZIP) -X \
 		"$(ROOT)/$@" -@
 	@rm -rf "$(TEMP_DIR)"
 	@echo "Result: $@"

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,19 @@
 # Makefile by Roberto M.F. (Roboe)
 # https://github.com/WeAreFairphone/flashabe-zip_emojione
 
-SHELL     := /bin/bash
+SHELL       := /bin/bash
+
+# Dependencies
+CURL        := $(shell command -v curl 2>&1)
+ZIP         := $(shell command -v zip 2>&1)
+UNZIP       := $(shell command -v unzip 2>&1)
+ifeq ($(uname -s),"Darwin")
+  SHA256SUM := $(shell command -v gsha256sum 2>&1)
+  MKTEMP    := $(shell command -v gmktemp 2>&1)
+else
+  SHA256SUM := $(shell command -v sha256sum 2>&1)
+  MKTEMP    := $(shell command -v mktemp 2>&1)
+endif
 
 # Version and release
 VERSION      := 19.02.1
@@ -17,7 +29,7 @@ SOURCE       := ./src/
 FIRMWARE_DIR := ./src/firmware-update/
 EDIFY_BINARY := ./src/META-INF/com/google/android/update-binary
 EDIFY_SCRIPT := ./src/META-INF/com/google/android/updater-script
-TEMP_DIR     := $(shell mktemp --dry-run -d /tmp/modem.XXXXXXXX)
+TEMP_DIR     := $(shell $(MKTEMP) --dry-run -d /tmp/modem.XXXXXXXX)
 TEMP_EDIFY_DIR := $(TEMP_DIR)/META-INF/com/google/android/
 
 # Update ZIPs
@@ -33,12 +45,6 @@ FWUPDATE_URL      := $(OTA_URL)
 FWUPDATE_CHECKSUM := $(OTA_CHECKSUM)
 ### Images directory uses to be 'firmware-update' for OTA ZIPs and 'images' for manual ZIPs
 FWUPDATE_IMGSDIR  := firmware-update
-
-# Dependencies
-CURL      := $(shell command -v curl 2>&1)
-ZIP       := $(shell command -v zip 2>&1)
-UNZIP     := $(shell command -v unzip 2>&1)
-SHA256SUM := $(shell if [[ "$(uname -s)" == "Darwin" ]]; then command -v gsha256sum; else command -v sha256sum; fi)
 
 
 .PHONY: all build clean release install

--- a/README.md
+++ b/README.md
@@ -7,12 +7,15 @@ This repo host the code to generate a reproducible, flashable ZIP file (called `
 You can always download the latest `modem.zip` release from [this link](https://github.com/WeAreFairphone/modem_zip_generator/releases "Download latest modem.zip"). Also, previous releases can be found at the [releases page at GitHub](https://github.com/WeAreFairphone/modem_zip_generator/releases "Previous releases of the modem.zip").
 
 ### System requirements
-The project has been developed on GNU/Linux systems, it should however run on other UNIX systems, too. The following tools are required for the script to run:
+The following tools are required for the script to run:
  - GNU `make`
  - `bash`
  - `curl`
  - `zip` & `unzip`
  - `sha256sum`
+
+The project has been developed on GNU/Linux systems, it should however run on other UNIX systems, too. For Mac OS you'll need the GNU coreutils. Using [Homebrew](https://brew.sh): `$ brew install coreutils`.
+
 
 ### Build
 Clone the repository and execute `make build`, it will download and verify the official Fairphone 2 firmware images and extract the proprietary firmware images.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The following tools are required for the script to run:
  - `zip` & `unzip`
  - `sha256sum`
 
-The project has been developed on GNU/Linux systems, it should however run on other UNIX systems, too. For Mac OS you'll need the GNU coreutils. Using [Homebrew](https://brew.sh): `$ brew install coreutils`.
+The project has been developed on GNU/Linux systems, it should however run on other UNIX systems, too. For Mac OS you'll need the GNU coreutils and findutils. Using [Homebrew](https://brew.sh): `$ brew install coreutils findutils`.
 
 
 ### Build


### PR DESCRIPTION
(Apparently GitHub doesn't know how to reopen a Pull Request, so I'm recreating #7. Meh.)

**--> Must fix #4 once before merging. <--**

This PR specifically replaces `mktemp` with `gmktemp`. `gmktemp` is available in GNU coreutils (`$ brew install coreutils`).
I could have written the command like `mktemp -u` instead of `mktemp --dry-run`, but I decided to keep readability because we already need `coreutils` to provide `gsha256sum`.  

Please, @jfdhuiz, could you test this on your machine?