### PR TITLE
Update to 19021

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 SHELL     := /bin/bash
 
 # Version and release
-VERSION      := 18.10.0
+VERSION      := 19.02.1
 FLASHABLEZIP := ./build/modem.zip
 RELEASENAME  := $(shell date +"modem-$(VERSION)_%Y-%m-%d.zip")
 RELEASEZIP   := release/$(RELEASENAME)
@@ -22,15 +22,15 @@ TEMP_EDIFY_DIR := $(TEMP_DIR)/META-INF/com/google/android/
 
 # Update ZIPs
 ## OTA update for the Edify interpreter
-OTA_FILENAME := fp2-sibon-18.04.1-ota-userdebug.zip
+OTA_FILENAME := 19.02.1-sibon-dc48370a-ota.zip
 OTA_FILE     := ./updates/$(OTA_FILENAME)
-OTA_URL      := https://storage.googleapis.com/fairphone-updates/6cb84543-9614-425d-9ab4-9e80baca2b8f/$(OTA_FILENAME)
-OTA_CHECKSUM := 97b39681b773804c8e12177293171698395c43ad9458c7ba823c85c503f00500
+OTA_URL      := https://storage.googleapis.com/fairphone-updates/5a2d07a7-4402-4e3c-a57b-a6fdd5078c66/$(OTA_FILENAME)
+OTA_CHECKSUM := 7a36eb7e722e2f823eb228c9565c1d19febfdf1b3169c9e59b9791063647c045
 ## Update with desired firmware images (ota or manual)
 FWUPDATE_FILENAME := fp2-sibon-$(VERSION)-manual.zip
 FWUPDATE_FILE     := ./updates/$(FWUPDATE_FILENAME)
-FWUPDATE_URL      := https://storage.googleapis.com/fairphone-updates/0703921c-b837-40b0-bbf0-9da7f2607b08/$(FWUPDATE_FILENAME)
-FWUPDATE_CHECKSUM := 4b52e477c6c28a5fdb3a1b78a97eff0dd51c3111061dfc62ed784e6c57ca5ba6
+FWUPDATE_URL      := https://storage.googleapis.com/fairphone-updates/5a2d07a7-4402-4e3c-a57b-a6fdd5078c66/$(FWUPDATE_FILENAME)
+FWUPDATE_CHECKSUM := b46c4987e41350a144c6c9e188f94169e1cd0b04b6f653ad12c77c3fc9d2a081
 ### Images directory uses to be 'firmware-update' for OTA ZIPs and 'images' for manual ZIPs
 FWUPDATE_IMGSDIR  := images
 

--- a/src/META-INF/com/google/android/updater-script
+++ b/src/META-INF/com/google/android/updater-script
@@ -1,4 +1,4 @@
-get_device_compatible("FP2") == "OK" || abort("This package is for \"FP2\" devices; this is a \"" + getprop("ro.product.device") + "\".");
+assert(getprop("ro.product.device") == "FP2" || getprop("ro.build.product") == "FP2" || abort("E3004: This package is for device: FP2; this device is " + getprop("ro.product.device") + "."););
 set_progress(0.200000);
 
 ui_print("Patching firmware images...");


### PR DESCRIPTION
Use 19.02.1 firmware files.
Adjust syntax to check for device compatibility to work with the Android 7 update-binary.

Fixes #13